### PR TITLE
[TR-5] Merge email register feature

### DIFF
--- a/src/main/java/me/tiary/config/WebSecurityConfig.java
+++ b/src/main/java/me/tiary/config/WebSecurityConfig.java
@@ -23,6 +23,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -148,5 +150,10 @@ public class WebSecurityConfig {
     @Bean(name = "accessTokenProvider")
     public JwtProvider accessTokenProvider(final AccessTokenProperties properties) {
         return new JwtProvider(properties);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/me/tiary/controller/AccountController.java
+++ b/src/main/java/me/tiary/controller/AccountController.java
@@ -1,14 +1,15 @@
 package me.tiary.controller;
 
 import lombok.RequiredArgsConstructor;
+import me.tiary.dto.account.AccountCreationRequestDto;
+import me.tiary.dto.account.AccountCreationResponseDto;
 import me.tiary.service.AccountService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
@@ -22,5 +23,12 @@ public class AccountController {
     @RequestMapping(value = "/email/{email}", method = RequestMethod.HEAD)
     public ResponseEntity<Void> checkEmailDuplication(@PathVariable @NotBlank @Email final String email) {
         return (accountService.checkEmailDuplication(email)) ? (ResponseEntity.ok().build()) : (ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("")
+    public ResponseEntity<AccountCreationResponseDto> register(@RequestBody @Valid final AccountCreationRequestDto requestDto) {
+        final AccountCreationResponseDto result = accountService.register(requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 }

--- a/src/main/java/me/tiary/dto/account/AccountCreationRequestDto.java
+++ b/src/main/java/me/tiary/dto/account/AccountCreationRequestDto.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotBlank;
 @RequiredArgsConstructor
 @Builder
 @Getter
+@EqualsAndHashCode
 public class AccountCreationRequestDto {
     @NotBlank
     private final String profileUuid;

--- a/src/main/java/me/tiary/dto/account/AccountCreationRequestDto.java
+++ b/src/main/java/me/tiary/dto/account/AccountCreationRequestDto.java
@@ -1,0 +1,22 @@
+package me.tiary.dto.account;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@RequiredArgsConstructor
+@Builder
+@Getter
+public class AccountCreationRequestDto {
+    @NotBlank
+    private final String profileUuid;
+
+    @NotBlank
+    @Email
+    private final String email;
+
+    @NotBlank
+    private final String password;
+}

--- a/src/main/java/me/tiary/dto/account/AccountCreationResponseDto.java
+++ b/src/main/java/me/tiary/dto/account/AccountCreationResponseDto.java
@@ -1,0 +1,11 @@
+package me.tiary.dto.account;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@Getter
+public class AccountCreationResponseDto {
+    private final String email;
+}

--- a/src/main/java/me/tiary/dto/account/AccountCreationResponseDto.java
+++ b/src/main/java/me/tiary/dto/account/AccountCreationResponseDto.java
@@ -1,10 +1,10 @@
 package me.tiary.dto.account;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@RequiredArgsConstructor
+@Builder
 @Getter
 public class AccountCreationResponseDto {
     private final String email;

--- a/src/main/java/me/tiary/exception/AccountException.java
+++ b/src/main/java/me/tiary/exception/AccountException.java
@@ -1,0 +1,11 @@
+package me.tiary.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.tiary.exception.status.AccountStatus;
+
+@RequiredArgsConstructor
+@Getter
+public class AccountException extends RuntimeException {
+    private final AccountStatus status;
+}

--- a/src/main/java/me/tiary/exception/handler/controller/GlobalExceptionHandler.java
+++ b/src/main/java/me/tiary/exception/handler/controller/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package me.tiary.exception.handler.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import me.tiary.exception.AccountException;
 import me.tiary.exception.ProfileException;
 import me.tiary.exception.handler.ExceptionResponse;
+import me.tiary.exception.status.AccountStatus;
 import me.tiary.exception.status.ProfileStatus;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
@@ -45,6 +47,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("Constraint violation exception occurrence: {}", messages);
 
         return ResponseEntity.badRequest().body(new ExceptionResponse(messages));
+    }
+
+    @ExceptionHandler({AccountException.class})
+    public ResponseEntity<Object> handleAccountException(final AccountException ex) {
+        final AccountStatus status = ex.getStatus();
+
+        log.warn("Account exception occurrence: {}", status.getMessage());
+
+        return ResponseEntity.status(status.getHttpStatus()).body(new ExceptionResponse(List.of(status.getMessage())));
     }
 
     @ExceptionHandler({ProfileException.class})

--- a/src/main/java/me/tiary/exception/status/AccountStatus.java
+++ b/src/main/java/me/tiary/exception/status/AccountStatus.java
@@ -1,0 +1,18 @@
+package me.tiary.exception.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum AccountStatus {
+    UNREQUESTED_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST, "must request email verification"),
+    UNVERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "must verify email"),
+    NOT_EXISTING_PROFILE_UUID(HttpStatus.NOT_FOUND, "must be an existing profile uuid"),
+    EXISTING_EMAIL(HttpStatus.CONFLICT, "must not be an existing email"),
+    EXISTING_ANOTHER_ACCOUNT_ON_PROFILE(HttpStatus.CONFLICT, "must register to profile that has not account");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/me/tiary/repository/ProfileRepository.java
+++ b/src/main/java/me/tiary/repository/ProfileRepository.java
@@ -2,11 +2,16 @@ package me.tiary.repository;
 
 import me.tiary.domain.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    @Query("select p from Profile p left join fetch p.account where p.uuid = :uuid")
+    Optional<Profile> findByUuidLeftJoinFetchAccount(@Param("uuid") final String uuid);
+
     Optional<Profile> findByNickname(final String nickname);
 }

--- a/src/main/java/me/tiary/service/AccountService.java
+++ b/src/main/java/me/tiary/service/AccountService.java
@@ -1,7 +1,18 @@
 package me.tiary.service;
 
 import lombok.RequiredArgsConstructor;
+import me.tiary.domain.Account;
+import me.tiary.domain.Profile;
+import me.tiary.domain.Verification;
+import me.tiary.dto.account.AccountCreationRequestDto;
+import me.tiary.dto.account.AccountCreationResponseDto;
+import me.tiary.exception.AccountException;
+import me.tiary.exception.status.AccountStatus;
 import me.tiary.repository.AccountRepository;
+import me.tiary.repository.ProfileRepository;
+import me.tiary.repository.VerificationRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,7 +22,46 @@ import org.springframework.transaction.annotation.Transactional;
 public class AccountService {
     private final AccountRepository accountRepository;
 
+    private final ProfileRepository profileRepository;
+
+    private final VerificationRepository verificationRepository;
+
+    private final ModelMapper modelMapper;
+
+    private final PasswordEncoder passwordEncoder;
+
     public boolean checkEmailDuplication(final String email) {
         return accountRepository.findByEmail(email).isPresent();
+    }
+
+    @Transactional
+    public AccountCreationResponseDto register(final AccountCreationRequestDto requestDto) {
+        if (checkEmailDuplication(requestDto.getEmail())) {
+            throw new AccountException(AccountStatus.EXISTING_EMAIL);
+        }
+
+        final Verification verification = verificationRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new AccountException(AccountStatus.UNREQUESTED_EMAIL_VERIFICATION));
+
+        if (!verification.getState()) {
+            throw new AccountException(AccountStatus.UNVERIFIED_EMAIL);
+        }
+
+        final Profile profile = profileRepository.findByUuidLeftJoinFetchAccount(requestDto.getProfileUuid())
+                .orElseThrow(() -> new AccountException(AccountStatus.NOT_EXISTING_PROFILE_UUID));
+
+        if (profile.getAccount() != null) {
+            throw new AccountException(AccountStatus.EXISTING_ANOTHER_ACCOUNT_ON_PROFILE);
+        }
+
+        final Account account = Account.builder()
+                .profile(profile)
+                .email(requestDto.getEmail())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .build();
+
+        final Account result = accountRepository.save(account);
+
+        return modelMapper.map(result, AccountCreationResponseDto.class);
     }
 }

--- a/src/test/java/factory/domain/AccountFactory.java
+++ b/src/test/java/factory/domain/AccountFactory.java
@@ -1,0 +1,22 @@
+package factory.domain;
+
+import me.tiary.domain.Account;
+import me.tiary.domain.Profile;
+
+public final class AccountFactory {
+    public static Account createDefaultAccount(final Profile profile) {
+        return create(profile, "test@example.com", "test");
+    }
+
+    public static Account create(final Profile profile, final String email, final String password) {
+        final Account account = Account.builder()
+                .profile(profile)
+                .email(email)
+                .password(password)
+                .build();
+
+        account.createUuid();
+
+        return account;
+    }
+}

--- a/src/test/java/factory/domain/ProfileFactory.java
+++ b/src/test/java/factory/domain/ProfileFactory.java
@@ -1,0 +1,20 @@
+package factory.domain;
+
+import me.tiary.domain.Profile;
+
+public final class ProfileFactory {
+    public static Profile createDefaultProfile() {
+        return create("Test", "https://example.com/");
+    }
+
+    public static Profile create(final String nickname, final String picture) {
+        final Profile profile = Profile.builder()
+                .nickname(nickname)
+                .picture(picture)
+                .build();
+
+        profile.createUuid();
+
+        return profile;
+    }
+}

--- a/src/test/java/factory/domain/VerificationFactory.java
+++ b/src/test/java/factory/domain/VerificationFactory.java
@@ -1,0 +1,34 @@
+package factory.domain;
+
+import me.tiary.domain.Verification;
+import utility.StringUtility;
+
+public final class VerificationFactory {
+    public static Verification createUnverifiedVerification() {
+        return create(
+                "test@example.com",
+                StringUtility.generateRandomString(Verification.CODE_MAX_LENGTH),
+                false
+        );
+    }
+
+    public static Verification createVerifiedVerification() {
+        return create(
+                "test@example.com",
+                StringUtility.generateRandomString(Verification.CODE_MAX_LENGTH),
+                true
+        );
+    }
+
+    public static Verification create(final String email, final String code, final Boolean state) {
+        final Verification verification = Verification.builder()
+                .email(email)
+                .code(code)
+                .state(state)
+                .build();
+
+        verification.createUuid();
+
+        return verification;
+    }
+}

--- a/src/test/java/factory/dto/account/AccountCreationRequestDtoFactory.java
+++ b/src/test/java/factory/dto/account/AccountCreationRequestDtoFactory.java
@@ -1,0 +1,17 @@
+package factory.dto.account;
+
+import me.tiary.dto.account.AccountCreationRequestDto;
+
+public final class AccountCreationRequestDtoFactory {
+    public static AccountCreationRequestDto createDefaultAccountCreationRequestDto(final String profileUuid) {
+        return create(profileUuid, "test@example.com", "test");
+    }
+
+    public static AccountCreationRequestDto create(final String profileUuid, final String email, final String password) {
+        return AccountCreationRequestDto.builder()
+                .profileUuid(profileUuid)
+                .email(email)
+                .password(password)
+                .build();
+    }
+}

--- a/src/test/java/factory/dto/account/AccountCreationResponseDtoFactory.java
+++ b/src/test/java/factory/dto/account/AccountCreationResponseDtoFactory.java
@@ -1,0 +1,15 @@
+package factory.dto.account;
+
+import me.tiary.dto.account.AccountCreationResponseDto;
+
+public final class AccountCreationResponseDtoFactory {
+    public static AccountCreationResponseDto createDefaultAccountCreationResponseDto() {
+        return create("test@example.com");
+    }
+
+    public static AccountCreationResponseDto create(final String email) {
+        return AccountCreationResponseDto.builder()
+                .email(email)
+                .build();
+    }
+}

--- a/src/test/java/me/tiary/controller/accountcontroller/RegisterTest.java
+++ b/src/test/java/me/tiary/controller/accountcontroller/RegisterTest.java
@@ -1,0 +1,437 @@
+package me.tiary.controller.accountcontroller;
+
+import com.google.gson.Gson;
+import factory.dto.account.AccountCreationRequestDtoFactory;
+import factory.dto.account.AccountCreationResponseDtoFactory;
+import me.tiary.controller.AccountController;
+import me.tiary.dto.account.AccountCreationRequestDto;
+import me.tiary.dto.account.AccountCreationResponseDto;
+import me.tiary.exception.AccountException;
+import me.tiary.exception.handler.ExceptionResponse;
+import me.tiary.exception.handler.controller.GlobalExceptionHandler;
+import me.tiary.exception.status.AccountStatus;
+import me.tiary.service.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[AccountController] register")
+class RegisterTest {
+    public static final String URL = "/api/account";
+
+    @InjectMocks
+    private AccountController accountController;
+
+    @Mock
+    private AccountService accountService;
+
+    private MockMvc mockMvc;
+
+    private Gson gson;
+
+    @BeforeEach
+    void beforeEach() {
+        mockMvc = MockMvcBuilders.standaloneSetup(accountController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        gson = new Gson();
+    }
+
+    @Test
+    @DisplayName("[Fail] profile uuid is null")
+    void failIfProfileUuidIsNull() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                null, "test@example.com", "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] profile uuid is empty")
+    void failIfProfileUuidIsEmpty() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                "", "test@example.com", "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] profile uuid is blank")
+    void failIfProfileUuidIsBlank() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                " ", "test@example.com", "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] email is null")
+    void failIfEmailIsNull() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), null, "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] email is empty")
+    void failIfEmailIsEmpty() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), "", "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] email is blank")
+    void failIfEmailIsBlank() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), " ", "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] email is invalid format")
+    void failIfEmailIsInvalidFormat() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), "test", "test"
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] password is null")
+    void failIfPasswordIsNull() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), "test@example.com", null
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] password is empty")
+    void failIfPasswordIsEmpty() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), "test@example.com", ""
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] password is blank")
+    void failIfPasswordIsBlank() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.create(
+                UUID.randomUUID().toString(), "test@example.com", " "
+        );
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Fail] email does exist")
+    void failIfEmailDoesExist() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        doThrow(new AccountException(AccountStatus.EXISTING_EMAIL))
+                .when(accountService)
+                .register(eq(requestDto));
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(AccountStatus.EXISTING_EMAIL.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(AccountStatus.EXISTING_EMAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Fail] email verification is not requested")
+    void failEmailVerificationIsNotRequested() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        doThrow(new AccountException(AccountStatus.UNREQUESTED_EMAIL_VERIFICATION))
+                .when(accountService)
+                .register(eq(requestDto));
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(AccountStatus.UNREQUESTED_EMAIL_VERIFICATION.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(AccountStatus.UNREQUESTED_EMAIL_VERIFICATION.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Fail] email is not verified")
+    void failIfEmailIsNotVerified() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        doThrow(new AccountException(AccountStatus.UNVERIFIED_EMAIL))
+                .when(accountService)
+                .register(eq(requestDto));
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(AccountStatus.UNVERIFIED_EMAIL.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(AccountStatus.UNVERIFIED_EMAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Fail] profile uuid does not exist")
+    void failProfileUuidDoesNotExist() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        doThrow(new AccountException(AccountStatus.NOT_EXISTING_PROFILE_UUID))
+                .when(accountService)
+                .register(eq(requestDto));
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(AccountStatus.NOT_EXISTING_PROFILE_UUID.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(AccountStatus.NOT_EXISTING_PROFILE_UUID.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Fail] profile already has account")
+    void failIfProfileAlreadyHasAccount() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        doThrow(new AccountException(AccountStatus.EXISTING_ANOTHER_ACCOUNT_ON_PROFILE))
+                .when(accountService)
+                .register(eq(requestDto));
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(AccountStatus.EXISTING_ANOTHER_ACCOUNT_ON_PROFILE.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(AccountStatus.EXISTING_ANOTHER_ACCOUNT_ON_PROFILE.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Success] account is creatable")
+    void successIfAccountIsCreatable() throws Exception {
+        // Given
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        final AccountCreationResponseDto responseDto = AccountCreationResponseDtoFactory.createDefaultAccountCreationResponseDto();
+
+        doReturn(responseDto)
+                .when(accountService)
+                .register(eq(requestDto));
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gson.toJson(requestDto))
+        );
+
+        final AccountCreationResponseDto response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                AccountCreationResponseDto.class
+        );
+
+        // Then
+        resultActions.andExpect(status().isCreated());
+        assertThat(response.getEmail()).isEqualTo(responseDto.getEmail());
+    }
+}

--- a/src/test/java/me/tiary/repository/profilerepository/FindByUuidLeftJoinFetchAccountTest.java
+++ b/src/test/java/me/tiary/repository/profilerepository/FindByUuidLeftJoinFetchAccountTest.java
@@ -1,0 +1,100 @@
+package me.tiary.repository.profilerepository;
+
+import me.tiary.domain.Account;
+import me.tiary.domain.Profile;
+import me.tiary.repository.AccountRepository;
+import me.tiary.repository.ProfileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import utility.JpaUtility;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("[ProfileRepository] findByUuidLeftJoinFetchAccount")
+class FindByUuidLeftJoinFetchAccountTest {
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Test
+    @DisplayName("[Success] uuid does not exist")
+    void successIfUuidDoesNotExist() {
+        // When
+        final Optional<Profile> result = profileRepository.findByUuidLeftJoinFetchAccount("45b2e8bc-df75-4c56-8148-ee03643c11b5");
+
+        // Then
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[Success] uuid does exist and account is null")
+    void successIfUuidDoesExistAndAccountIsNull() {
+        // Given
+        final Profile profile = profileRepository.save(
+                Profile.builder()
+                        .nickname("Test")
+                        .picture("https://example.com/")
+                        .build()
+        );
+
+        JpaUtility.flushAndClear(em);
+
+        // When
+        final Optional<Profile> result = profileRepository.findByUuidLeftJoinFetchAccount(profile.getUuid());
+
+        // Then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get().getUuid()).isEqualTo(profile.getUuid());
+        assertThat(result.get().getNickname()).isEqualTo("Test");
+        assertThat(result.get().getPicture()).isEqualTo("https://example.com/");
+        assertThat(result.get().getAccount()).isNull();
+    }
+
+    @Test
+    @DisplayName("[Success] uuid does exist and account is not null")
+    void successIfUuidDoesExistAndAccountIsNotNull() {
+        // Given
+        final Profile profile = profileRepository.save(
+                Profile.builder()
+                        .nickname("Test")
+                        .picture("https://example.com/")
+                        .build()
+        );
+
+        accountRepository.save(
+                Account.builder()
+                        .profile(profile)
+                        .email("test@example.com")
+                        .password("test")
+                        .build()
+        );
+
+        JpaUtility.flushAndClear(em);
+
+        // When
+        final Optional<Profile> result = profileRepository.findByUuidLeftJoinFetchAccount(profile.getUuid());
+
+        // Then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get().getUuid()).isEqualTo(profile.getUuid());
+        assertThat(result.get().getNickname()).isEqualTo("Test");
+        assertThat(result.get().getPicture()).isEqualTo("https://example.com/");
+        assertThat(result.get().getAccount()).isNotNull();
+    }
+}

--- a/src/test/java/me/tiary/service/accountservice/RegisterTest.java
+++ b/src/test/java/me/tiary/service/accountservice/RegisterTest.java
@@ -1,0 +1,232 @@
+package me.tiary.service.accountservice;
+
+import factory.domain.AccountFactory;
+import factory.domain.ProfileFactory;
+import factory.domain.VerificationFactory;
+import factory.dto.account.AccountCreationRequestDtoFactory;
+import me.tiary.domain.Account;
+import me.tiary.domain.Profile;
+import me.tiary.domain.Verification;
+import me.tiary.dto.account.AccountCreationRequestDto;
+import me.tiary.dto.account.AccountCreationResponseDto;
+import me.tiary.exception.AccountException;
+import me.tiary.exception.status.AccountStatus;
+import me.tiary.repository.AccountRepository;
+import me.tiary.repository.ProfileRepository;
+import me.tiary.repository.VerificationRepository;
+import me.tiary.service.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.config.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[AccountService] register")
+class RegisterTest {
+    @InjectMocks
+    private AccountService accountService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private VerificationRepository verificationRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    @Spy
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void beforeEach() {
+        modelMapper.getConfiguration()
+                .setFieldMatchingEnabled(true)
+                .setFieldAccessLevel(Configuration.AccessLevel.PRIVATE);
+    }
+
+    @Test
+    @DisplayName("[Fail] email does exist")
+    void failIfEmailDoesExist() {
+        // Given
+        final Account account = AccountFactory.createDefaultAccount(ProfileFactory.createDefaultProfile());
+
+        doReturn(Optional.ofNullable(account))
+                .when(accountRepository)
+                .findByEmail(eq(account.getEmail()));
+
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        // When
+        final AccountException result = assertThrows(AccountException.class, () -> accountService.register(requestDto));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(AccountStatus.EXISTING_EMAIL);
+    }
+
+    @Test
+    @DisplayName("[Fail] email verification is not requested")
+    void failEmailVerificationIsNotRequested() {
+        // Given
+        doReturn(Optional.empty())
+                .when(accountRepository)
+                .findByEmail(any(String.class));
+
+        doReturn(Optional.empty())
+                .when(verificationRepository)
+                .findByEmail(any(String.class));
+
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        // When
+        final AccountException result = assertThrows(AccountException.class, () -> accountService.register(requestDto));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(AccountStatus.UNREQUESTED_EMAIL_VERIFICATION);
+    }
+
+    @Test
+    @DisplayName("[Fail] email is not verified")
+    void failIfEmailIsNotVerified() {
+        // Given
+        doReturn(Optional.empty())
+                .when(accountRepository)
+                .findByEmail(any(String.class));
+
+        final Verification unverifiedVerification = VerificationFactory.createUnverifiedVerification();
+
+        doReturn(Optional.ofNullable(unverifiedVerification))
+                .when(verificationRepository)
+                .findByEmail(eq(unverifiedVerification.getEmail()));
+
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        // When
+        final AccountException result = assertThrows(AccountException.class, () -> accountService.register(requestDto));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(AccountStatus.UNVERIFIED_EMAIL);
+    }
+
+    @Test
+    @DisplayName("[Fail] profile uuid does not exist")
+    void failProfileUuidDoesNotExist() {
+        // Given
+        doReturn(Optional.empty())
+                .when(accountRepository)
+                .findByEmail(any(String.class));
+
+        final Verification verifiedVerification = VerificationFactory.createVerifiedVerification();
+
+        doReturn(Optional.ofNullable(verifiedVerification))
+                .when(verificationRepository)
+                .findByEmail(eq(verifiedVerification.getEmail()));
+
+        doReturn(Optional.empty())
+                .when(profileRepository)
+                .findByUuidLeftJoinFetchAccount(any(String.class));
+
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                UUID.randomUUID().toString()
+        );
+
+        // When
+        final AccountException result = assertThrows(AccountException.class, () -> accountService.register(requestDto));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(AccountStatus.NOT_EXISTING_PROFILE_UUID);
+    }
+
+    @Test
+    @DisplayName("[Fail] profile already has account")
+    void failIfProfileAlreadyHasAccount() {
+        // Given
+        doReturn(Optional.empty())
+                .when(accountRepository)
+                .findByEmail(any(String.class));
+
+        final Verification verifiedVerification = VerificationFactory.createVerifiedVerification();
+
+        doReturn(Optional.ofNullable(verifiedVerification))
+                .when(verificationRepository)
+                .findByEmail(eq(verifiedVerification.getEmail()));
+
+        final Profile profile = ProfileFactory.createDefaultProfile();
+
+        AccountFactory.createDefaultAccount(profile);
+
+        doReturn(Optional.ofNullable(profile))
+                .when(profileRepository)
+                .findByUuidLeftJoinFetchAccount(eq(profile.getUuid()));
+
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                profile.getUuid()
+        );
+
+        // When
+        final AccountException result = assertThrows(AccountException.class, () -> accountService.register(requestDto));
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(AccountStatus.EXISTING_ANOTHER_ACCOUNT_ON_PROFILE);
+    }
+
+    @Test
+    @DisplayName("[Success] account is creatable")
+    void successIfAccountIsCreatable() {
+        // Given
+        doReturn(Optional.empty())
+                .when(accountRepository)
+                .findByEmail(any(String.class));
+
+        final Verification verifiedVerification = VerificationFactory.createVerifiedVerification();
+
+        doReturn(Optional.ofNullable(verifiedVerification))
+                .when(verificationRepository)
+                .findByEmail(eq(verifiedVerification.getEmail()));
+
+        final Profile profile = ProfileFactory.createDefaultProfile();
+
+        doReturn(Optional.ofNullable(profile))
+                .when(profileRepository)
+                .findByUuidLeftJoinFetchAccount(eq(profile.getUuid()));
+
+        doReturn(AccountFactory.createDefaultAccount(ProfileFactory.createDefaultProfile()))
+                .when(accountRepository)
+                .save(any(Account.class));
+
+        final AccountCreationRequestDto requestDto = AccountCreationRequestDtoFactory.createDefaultAccountCreationRequestDto(
+                profile.getUuid()
+        );
+
+        // When
+        final AccountCreationResponseDto result = accountService.register(requestDto);
+
+        // Then
+        assertThat(result.getEmail()).isEqualTo(requestDto.getEmail());
+    }
+}

--- a/src/test/java/utility/JpaUtility.java
+++ b/src/test/java/utility/JpaUtility.java
@@ -1,0 +1,10 @@
+package utility;
+
+import javax.persistence.EntityManager;
+
+public final class JpaUtility {
+    public static void flushAndClear(final EntityManager em) {
+        em.flush();
+        em.clear();
+    }
+}


### PR DESCRIPTION
## Description

Merge email register feature

## Changes

- Create email register API
- Create email register business logic
- Create profile data access by UUID
- Create password encoder bean
- Create account exception
- Add account exception handler to global exception handler
- Create domain factories and DTO factory for test
- Create JPA utility to flush and clear entity manager