### PR TITLE
[TRY-239] Add tag filtering

### DIFF
--- a/src/main/java/me/tiary/controller/TilController.java
+++ b/src/main/java/me/tiary/controller/TilController.java
@@ -45,11 +45,12 @@ public class TilController {
 
     @GetMapping("/list/{nickname}")
     public ResponseEntity<TilListReadResponseDto> readTilList(@PathVariable @NotBlank @Size(max = Profile.NICKNAME_MAX_LENGTH) final String nickname,
+                                                              @RequestParam(required = false) final String tag,
                                                               @RequestParam final int page,
                                                               @RequestParam final int size) {
         final Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
 
-        final TilListReadResponseDto result = tilService.readTilList(nickname, pageable);
+        final TilListReadResponseDto result = (tag == null) ? (tilService.readTilList(nickname, pageable)) : (tilService.readTilListByTag(nickname, tag, pageable));
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/me/tiary/controller/ViewController.java
+++ b/src/main/java/me/tiary/controller/ViewController.java
@@ -57,6 +57,7 @@ public class ViewController {
 
     @GetMapping("/profile/{nickname}")
     public String directProfileView(@PathVariable @NotBlank @Size(max = Profile.NICKNAME_MAX_LENGTH) final String nickname,
+                                    @RequestParam(required = false) final String tag,
                                     @RequestParam final int page,
                                     @RequestParam final int size,
                                     @AuthenticationPrincipal final MemberDetails memberDetails,
@@ -69,6 +70,8 @@ public class ViewController {
 
         model.addAttribute(ModelParameterAttribute.PROFILE_NICKNAME.getName(), nickname);
         model.addAttribute(ModelParameterAttribute.EDIT_PERMISSION.getName(), false);
+
+        model.addAttribute(ModelParameterAttribute.TAG.getName(), tag);
 
         model.addAttribute(ModelParameterAttribute.PAGE.getName(), page);
         model.addAttribute(ModelParameterAttribute.SIZE.getName(), size);
@@ -176,6 +179,7 @@ public class ViewController {
         PROFILE_NICKNAME("nickname"),
         TIL_UUID("uuid"),
         EDIT_PERMISSION("editPermission"),
+        TAG("tag"),
         PAGE("page"),
         SIZE("size");
 

--- a/src/main/java/me/tiary/exception/status/TilStatus.java
+++ b/src/main/java/me/tiary/exception/status/TilStatus.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum TilStatus {
     NOT_EXISTING_PROFILE(HttpStatus.NOT_FOUND, "must be an existing profile"),
     NOT_EXISTING_TIL(HttpStatus.NOT_FOUND, "must be an existing til"),
+    NOT_EXISTING_TAG(HttpStatus.NOT_FOUND, "must be an existing tag"),
     NOT_AUTHORIZED_MEMBER(HttpStatus.FORBIDDEN, "must be an authorized member");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/me/tiary/repository/TilTagRepository.java
+++ b/src/main/java/me/tiary/repository/TilTagRepository.java
@@ -2,6 +2,8 @@ package me.tiary.repository;
 
 import me.tiary.domain.TilTag;
 import me.tiary.domain.composite.TilTagId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,10 @@ import java.util.List;
 
 @Repository
 public interface TilTagRepository extends JpaRepository<TilTag, TilTagId> {
+    @Query(value = "select tt from TilTag tt join fetch tt.til where tt.til.profile.nickname = :tilProfileNickname and tt.tag.name = :tagName",
+            countQuery = "select count(tt) from TilTag tt where tt.til.profile.nickname = :tilProfileNickname and tt.tag.name = :tagName")
+    Page<TilTag> findByTilProfileNicknameAndTagNameJoinFetchTil(@Param("tilProfileNickname") final String tilProfileNickname, @Param("tagName") final String tagName, final Pageable pageable);
+
     List<TilTag> findAllByTilUuid(final String tilUuid);
 
     @Query("select tt from TilTag tt join fetch tt.tag where tt.til.uuid = :tilUuid")

--- a/src/main/resources/static/js/profile.js
+++ b/src/main/resources/static/js/profile.js
@@ -137,13 +137,13 @@ $(function () {
         url: `/api/tag/list/profile/${nickname}`
     }).done(function (data) {
         data.tags.forEach(tag => {
-            $('#tags').append(`<a>${tag}</a>`);
+            $('#tags').append(`<a href="/profile/${nickname}?tag=${tag}&page=1&size=5">${tag}</a>`);
         });
     });
 
     $.ajax({
         type: 'GET',
-        url: `/api/til/list/${nickname}?page=${page - 1}&size=${size}`
+        url: `/api/til/list/${nickname}?${(tag == null) ? ("") : ("tag=" + tag + "&")}page=${page - 1}&size=${size}`
     }).done(function (data) {
         const tils = data.tils;
         const totalPages = data.totalPages;

--- a/src/main/resources/templates/view/profile.html
+++ b/src/main/resources/templates/view/profile.html
@@ -18,6 +18,8 @@
     <script th:inline="javascript">
         const nickname = [[${nickname}]];
 
+        const tag = [[${tag}]];
+
         const page = [[${page}]];
         const size = [[${size}]];
     </script>

--- a/src/test/java/me/tiary/config/websecurityconfig/SecurityFilterChainIntegrationTest.java
+++ b/src/test/java/me/tiary/config/websecurityconfig/SecurityFilterChainIntegrationTest.java
@@ -169,9 +169,11 @@ class SecurityFilterChainIntegrationTest {
         resultActions.andExpect(status().is(not(HttpStatus.FORBIDDEN.value())));
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] member requests profile view")
-    void successIfMemberRequestsProfileView() throws Exception {
+    void successIfMemberRequestsProfileView(final String tag) throws Exception {
         // Given
         final String url = ViewUrl.PROFILE.getEntireUrl() + FactoryPreset.NICKNAME;
 
@@ -181,6 +183,7 @@ class SecurityFilterChainIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
                         .cookie(new Cookie(AccessTokenProperties.COOKIE_NAME, accessToken))
@@ -190,21 +193,24 @@ class SecurityFilterChainIntegrationTest {
         resultActions.andExpect(status().is(not(HttpStatus.FORBIDDEN.value())));
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] anonymous requests profile view")
-    void successIfAnonymousRequestsProfileView() throws Exception {
+    void successIfAnonymousRequestsProfileView(final String tag) throws Exception {
         // Given
         final String url = ViewUrl.PROFILE.getEntireUrl() + FactoryPreset.NICKNAME;
 
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
         );
 
         // Then
-        resultActions.andExpect(status().is(not(HttpStatus.FORBIDDEN.value())));
+        resultActions.andExpect(status().is(not(HttpStatus.UNAUTHORIZED.value())));
     }
 
     @Test

--- a/src/test/java/me/tiary/config/websecurityconfig/SecurityFilterChainIntegrationTest.java
+++ b/src/test/java/me/tiary/config/websecurityconfig/SecurityFilterChainIntegrationTest.java
@@ -34,6 +34,9 @@ import me.tiary.utility.common.StringUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -850,9 +853,11 @@ class SecurityFilterChainIntegrationTest {
         resultActions.andExpect(status().is(not(HttpStatus.FORBIDDEN.value())));
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] member requests til list read api")
-    void successIfMemberRequestsTilListReadApi() throws Exception {
+    void successIfMemberRequestsTilListReadApi(final String tag) throws Exception {
         // Given
         final String nickname = FactoryPreset.NICKNAME;
 
@@ -864,6 +869,7 @@ class SecurityFilterChainIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "0")
                         .param("size", "5")
                         .cookie(new Cookie(AccessTokenProperties.COOKIE_NAME, accessToken))
@@ -873,9 +879,11 @@ class SecurityFilterChainIntegrationTest {
         resultActions.andExpect(status().is(not(HttpStatus.FORBIDDEN.value())));
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] anonymous requests til list read api")
-    void successIfAnonymousRequestsTilListReadApi() throws Exception {
+    void successIfAnonymousRequestsTilListReadApi(final String tag) throws Exception {
         // Given
         final String nickname = FactoryPreset.NICKNAME;
 
@@ -884,12 +892,13 @@ class SecurityFilterChainIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "0")
                         .param("size", "5")
         );
 
         // Then
-        resultActions.andExpect(status().is(not(HttpStatus.FORBIDDEN.value())));
+        resultActions.andExpect(status().is(not(HttpStatus.UNAUTHORIZED.value())));
     }
 
     @Test

--- a/src/test/java/me/tiary/controller/tilcontroller/ReadTilListIntegrationTest.java
+++ b/src/test/java/me/tiary/controller/tilcontroller/ReadTilListIntegrationTest.java
@@ -1,13 +1,16 @@
 package me.tiary.controller.tilcontroller;
 
 import common.annotation.controller.ControllerIntegrationTest;
+import common.config.factory.FactoryPreset;
 import common.config.url.TilApiUrl;
 import me.tiary.controller.TilController;
 import me.tiary.domain.Profile;
 import me.tiary.service.TilService;
 import me.tiary.utility.common.StringUtility;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,15 +28,18 @@ class ReadTilListIntegrationTest {
     @MockBean
     private TilService tilService;
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Fail] nickname is blank")
-    void failIfNicknameIsBlank() throws Exception {
+    void failIfNicknameIsBlank(final String tag) throws Exception {
         // Given
         final String url = TilApiUrl.TIL_LIST_READ.getEntireUrl() + " ";
 
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "0")
                         .param("size", "5")
         );
@@ -42,9 +48,11 @@ class ReadTilListIntegrationTest {
         resultActions.andExpect(status().isBadRequest());
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Fail] nickname exceeds max length")
-    void failIfNicknameExceedsMaxLength() throws Exception {
+    void failIfNicknameExceedsMaxLength(final String tag) throws Exception {
         // Given
         final String nickname = StringUtility.generateRandomString(Profile.NICKNAME_MAX_LENGTH + 1);
 
@@ -53,6 +61,7 @@ class ReadTilListIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "0")
                         .param("size", "5")
         );

--- a/src/test/java/me/tiary/controller/tilcontroller/ReadTilListTest.java
+++ b/src/test/java/me/tiary/controller/tilcontroller/ReadTilListTest.java
@@ -56,8 +56,8 @@ class ReadTilListTest {
     }
 
     @Test
-    @DisplayName("[Fail] profile does not exist")
-    void failIfProfileDoesNotExist() throws Exception {
+    @DisplayName("[Fail] profile does not exist when tag is not provided")
+    void failIfProfileDoesNotExistWhenTagIsNotProvided() throws Exception {
         // Given
         final String nickname = FactoryPreset.NICKNAME;
 
@@ -89,8 +89,8 @@ class ReadTilListTest {
     }
 
     @Test
-    @DisplayName("[Success] tils do not exist")
-    void successIfTilsDoNotExist() throws Exception {
+    @DisplayName("[Success] tils do not exist when tag is not provided")
+    void successIfTilsDoNotExistWhenTagIsNotProvided() throws Exception {
         // Given
         final String nickname = FactoryPreset.NICKNAME;
 
@@ -125,8 +125,8 @@ class ReadTilListTest {
     }
 
     @Test
-    @DisplayName("[Success] tils do exist")
-    void successIfTilsDoExist() throws Exception {
+    @DisplayName("[Success] tils do exist when tag is not provided")
+    void successIfTilsDoExistWhenTagIsNotProvided() throws Exception {
         // Given
         final String nickname = FactoryPreset.NICKNAME;
 
@@ -143,6 +143,119 @@ class ReadTilListTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("page", "0")
+                        .param("size", "5")
+        );
+
+        final TilListReadResponseDto response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                TilListReadResponseDto.class
+        );
+
+        // Then
+        resultActions.andExpect(status().isOk());
+        assertThat(response.getTils().get(0).getUuid()).hasSize(36);
+        assertThat(response.getTils().get(0).getTitle()).isEqualTo(responseDto.getTils().get(0).getTitle());
+        assertThat(response.getTils().get(0).getContent()).isEqualTo(responseDto.getTils().get(0).getContent());
+        assertThat(response.getTotalPages()).isEqualTo(responseDto.getTotalPages());
+    }
+
+    @Test
+    @DisplayName("[Fail] profile does not exist when tag is provided")
+    void failIfProfileDoesNotExistWhenTagIsProvided() throws Exception {
+        // Given
+        final String nickname = FactoryPreset.NICKNAME;
+
+        final String url = TilApiUrl.TIL_LIST_READ.getEntireUrl() + nickname;
+
+        final String tag = FactoryPreset.TAG;
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        doThrow(new TilException(TilStatus.NOT_EXISTING_PROFILE))
+                .when(tilService)
+                .readTilListByTag(nickname, tag, pageable);
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
+                        .param("page", "0")
+                        .param("size", "5")
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(TilStatus.NOT_EXISTING_PROFILE.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(TilStatus.NOT_EXISTING_PROFILE.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Fail] tag does not exist when tag is provided")
+    void failIfTagDoesNotExistWhenTagIsProvided() throws Exception {
+        // Given
+        final String nickname = FactoryPreset.NICKNAME;
+
+        final String url = TilApiUrl.TIL_LIST_READ.getEntireUrl() + nickname;
+
+        final String tag = FactoryPreset.TAG;
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        doThrow(new TilException(TilStatus.NOT_EXISTING_TAG))
+                .when(tilService)
+                .readTilListByTag(nickname, tag, pageable);
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
+                        .param("page", "0")
+                        .param("size", "5")
+        );
+
+        final ExceptionResponse response = gson.fromJson(
+                resultActions.andReturn()
+                        .getResponse()
+                        .getContentAsString(StandardCharsets.UTF_8),
+                ExceptionResponse.class
+        );
+
+        // Then
+        resultActions.andExpect(status().is(TilStatus.NOT_EXISTING_TAG.getHttpStatus().value()));
+        assertThat(response.getMessages()).contains(TilStatus.NOT_EXISTING_TAG.getMessage());
+    }
+
+    @Test
+    @DisplayName("[Success] tils do exist when tag is provided")
+    void successIfTilsDoExistWhenTagIsProvided() throws Exception {
+        // Given
+        final String nickname = FactoryPreset.NICKNAME;
+
+        final String url = TilApiUrl.TIL_LIST_READ.getEntireUrl() + nickname;
+
+        final String tag = FactoryPreset.TAG;
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        final TilListReadResponseDto responseDto = TilListReadResponseDtoFactory.createDefaultTilListReadResponseDto();
+
+        doReturn(responseDto)
+                .when(tilService)
+                .readTilListByTag(nickname, tag, pageable);
+
+        // When
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "0")
                         .param("size", "5")
         );

--- a/src/test/java/me/tiary/controller/viewcontroller/DirectProfileViewIntegrationTest.java
+++ b/src/test/java/me/tiary/controller/viewcontroller/DirectProfileViewIntegrationTest.java
@@ -10,7 +10,9 @@ import me.tiary.service.ProfileService;
 import me.tiary.service.TilService;
 import me.tiary.utility.common.StringUtility;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,15 +37,18 @@ class DirectProfileViewIntegrationTest {
     @MockBean
     private TilService tilService;
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Fail] nickname is blank")
-    void failIfNicknameIsBlank() throws Exception {
+    void failIfNicknameIsBlank(final String tag) throws Exception {
         // Given
         final String url = ViewUrl.PROFILE.getEntireUrl() + " ";
 
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
         );
@@ -52,9 +57,11 @@ class DirectProfileViewIntegrationTest {
         resultActions.andExpect(status().isBadRequest());
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Fail] nickname exceeds max length")
-    void failIfNicknameExceedsMaxLength() throws Exception {
+    void failIfNicknameExceedsMaxLength(final String tag) throws Exception {
         // Given
         final String nickname = StringUtility.generateRandomString(Profile.NICKNAME_MAX_LENGTH + 1);
 
@@ -63,6 +70,7 @@ class DirectProfileViewIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
         );
@@ -71,9 +79,11 @@ class DirectProfileViewIntegrationTest {
         resultActions.andExpect(status().isBadRequest());
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Fail] nickname does not exist")
-    void failIfNicknameDoesNotExist() throws Exception {
+    void failIfNicknameDoesNotExist(final String tag) throws Exception {
         // Given
         final String url = ViewUrl.PROFILE.getEntireUrl() + FactoryPreset.NICKNAME;
 
@@ -84,6 +94,7 @@ class DirectProfileViewIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
         );
@@ -92,9 +103,11 @@ class DirectProfileViewIntegrationTest {
         resultActions.andExpect(status().isFound());
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] anonymous views someone else profile")
-    void successIfAnonymousViewsSomeoneElseProfile() throws Exception {
+    void successIfAnonymousViewsSomeoneElseProfile(final String tag) throws Exception {
         // Given
         final String url = ViewUrl.PROFILE.getEntireUrl() + FactoryPreset.NICKNAME;
 
@@ -105,6 +118,7 @@ class DirectProfileViewIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
         );
@@ -114,9 +128,11 @@ class DirectProfileViewIntegrationTest {
         resultActions.andExpect(content().contentType("text/html;charset=UTF-8"));
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] member views someone else profile")
-    void successIfMemberViewsSomeoneElseProfile() throws Exception {
+    void successIfMemberViewsSomeoneElseProfile(final String tag) throws Exception {
         // Given
         final String nickname = StringUtility.generateRandomString(Profile.NICKNAME_MAX_LENGTH);
 
@@ -136,6 +152,7 @@ class DirectProfileViewIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
                         .cookie(new Cookie(AccessTokenProperties.COOKIE_NAME, accessToken))
@@ -146,9 +163,11 @@ class DirectProfileViewIntegrationTest {
         resultActions.andExpect(content().contentType("text/html;charset=UTF-8"));
     }
 
-    @Test
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {FactoryPreset.TAG})
     @DisplayName("[Success] member views own profile")
-    void successIfMemberViewsOwnProfile() throws Exception {
+    void successIfMemberViewsOwnProfile(final String tag) throws Exception {
         // Given
         final String url = ViewUrl.PROFILE.getEntireUrl() + FactoryPreset.NICKNAME;
 
@@ -166,6 +185,7 @@ class DirectProfileViewIntegrationTest {
         // When
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)
+                        .param("tag", tag)
                         .param("page", "1")
                         .param("size", "5")
                         .cookie(new Cookie(AccessTokenProperties.COOKIE_NAME, accessToken))

--- a/src/test/java/me/tiary/repository/tiltagrepository/FindByTilProfileNicknameAndTagNameJoinFetchTilIntegrationTest.java
+++ b/src/test/java/me/tiary/repository/tiltagrepository/FindByTilProfileNicknameAndTagNameJoinFetchTilIntegrationTest.java
@@ -1,0 +1,206 @@
+package me.tiary.repository.tiltagrepository;
+
+import common.annotation.repository.RepositoryIntegrationTest;
+import common.config.factory.FactoryPreset;
+import common.factory.domain.ProfileFactory;
+import common.factory.domain.TagFactory;
+import common.factory.domain.TilFactory;
+import common.factory.domain.TilTagFactory;
+import common.utility.JpaUtility;
+import me.tiary.domain.Profile;
+import me.tiary.domain.Tag;
+import me.tiary.domain.Til;
+import me.tiary.domain.TilTag;
+import me.tiary.repository.ProfileRepository;
+import me.tiary.repository.TagRepository;
+import me.tiary.repository.TilRepository;
+import me.tiary.repository.TilTagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryIntegrationTest
+@DisplayName("[TilTagRepository - Integration] findByTilProfileNicknameAndTagNameJoinFetchTil")
+class FindByTilProfileNicknameAndTagNameJoinFetchTilIntegrationTest {
+    @Autowired
+    private TilTagRepository tilTagRepository;
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Autowired
+    private TilRepository tilRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private Profile profile;
+
+    private Tag tag;
+
+    @BeforeEach
+    void beforeEach() {
+        profile = profileRepository.save(ProfileFactory.createDefaultProfile());
+
+        tag = tagRepository.save(TagFactory.createDefaultTag());
+
+        JpaUtility.flushAndClear(em);
+    }
+
+    @Test
+    @DisplayName("[Success] til tags for profile do not exist")
+    void successIfTilTagsForProfileDoNotExist() {
+        // Given
+        final Profile someoneElseProfile = profileRepository.save(ProfileFactory.create("Someone else " + profile.getNickname(), FactoryPreset.PICTURE));
+
+        final List<TilTag> tilTags = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            final Til til = tilRepository.save(TilFactory.createDefaultTil(someoneElseProfile));
+
+            tilTags.add(TilTagFactory.create(til, tag));
+        }
+
+        tilTagRepository.saveAll(tilTags);
+
+        JpaUtility.flushAndClear(em);
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        // When
+        final Page<TilTag> result = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[Success] til tags for tag do not exist")
+    void successIfTilTagsForTagDoNotExist() {
+        // Given
+        final Tag otherTag = tagRepository.save(TagFactory.create("Other " + tag.getName()));
+
+        final List<TilTag> tilTags = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            final Til til = tilRepository.save(TilFactory.createDefaultTil(profile));
+
+            tilTags.add(TilTagFactory.create(til, otherTag));
+        }
+
+        tilTagRepository.saveAll(tilTags);
+
+        JpaUtility.flushAndClear(em);
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        // When
+        final Page<TilTag> result = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[Success] til tags for profile and tag do not exist")
+    void successIfTilTagsForProfileAndTagDoNotExist() {
+        // Given
+        final Profile someoneElseProfile = profileRepository.save(ProfileFactory.create("Someone else " + profile.getNickname(), FactoryPreset.PICTURE));
+        final Tag otherTag = tagRepository.save(TagFactory.create("Other " + tag.getName()));
+
+        final List<TilTag> tilTags = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            final Til til = tilRepository.save(TilFactory.createDefaultTil(someoneElseProfile));
+
+            tilTags.add(TilTagFactory.create(til, otherTag));
+        }
+
+        tilTagRepository.saveAll(tilTags);
+
+        JpaUtility.flushAndClear(em);
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        // When
+        final Page<TilTag> result = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[Success] til tag number does not meet request")
+    void successIfTilTagNumberDoesNotMeetRequest() {
+        // Given
+        final List<TilTag> tilTags = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            final Til til = tilRepository.save(TilFactory.createDefaultTil(profile));
+
+            tilTags.add(TilTagFactory.create(til, tag));
+        }
+
+        tilTagRepository.saveAll(tilTags);
+
+        JpaUtility.flushAndClear(em);
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        // When
+        final Page<TilTag> result = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable);
+
+        // Then
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("[Success] til tag number does meet request")
+    void successIfTilTagNumberDoesMeetRequest() {
+        // Given
+        final List<TilTag> tilTags = new ArrayList<>();
+
+        for (int i = 0; i < 13; i++) {
+            final Til til = tilRepository.save(TilFactory.createDefaultTil(profile));
+
+            tilTags.add(TilTagFactory.create(til, tag));
+        }
+
+        tilTagRepository.saveAll(tilTags);
+
+        JpaUtility.flushAndClear(em);
+
+        final Pageable pageable1 = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        final Pageable pageable2 = PageRequest.of(1, 5, Sort.by("createdDate").descending());
+        final Pageable pageable3 = PageRequest.of(2, 5, Sort.by("createdDate").descending());
+
+        // When
+        final Page<TilTag> result1 = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable1);
+        final Page<TilTag> result2 = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable2);
+        final Page<TilTag> result3 = tilTagRepository.findByTilProfileNicknameAndTagNameJoinFetchTil(profile.getNickname(), tag.getName(), pageable3);
+
+        // Then
+        assertThat(result1.getTotalPages()).isEqualTo(3);
+        assertThat(result2.getTotalPages()).isEqualTo(3);
+        assertThat(result3.getTotalPages()).isEqualTo(3);
+        assertThat(result1.getContent()).hasSize(5);
+        assertThat(result2.getContent()).hasSize(5);
+        assertThat(result3.getContent()).hasSize(3);
+    }
+}

--- a/src/test/java/me/tiary/service/tilservice/ReadTilListByTagTest.java
+++ b/src/test/java/me/tiary/service/tilservice/ReadTilListByTagTest.java
@@ -1,0 +1,133 @@
+package me.tiary.service.tilservice;
+
+import common.annotation.service.ServiceTest;
+import common.config.factory.FactoryPreset;
+import common.factory.domain.ProfileFactory;
+import common.factory.domain.TagFactory;
+import common.factory.domain.TilFactory;
+import common.factory.domain.TilTagFactory;
+import me.tiary.domain.Profile;
+import me.tiary.domain.Tag;
+import me.tiary.domain.Til;
+import me.tiary.domain.TilTag;
+import me.tiary.dto.til.TilListReadResponseDto;
+import me.tiary.exception.TilException;
+import me.tiary.exception.status.TilStatus;
+import me.tiary.repository.ProfileRepository;
+import me.tiary.repository.TilTagRepository;
+import me.tiary.service.TilService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+
+@ServiceTest
+@DisplayName("[TilService] readTilListByTag")
+class ReadTilListByTagTest {
+    @InjectMocks
+    private TilService tilService;
+
+    @Mock
+    private TilTagRepository tilTagRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    @BeforeEach
+    void beforeEach() {
+        modelMapper.getConfiguration()
+                .setFieldMatchingEnabled(true)
+                .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE);
+    }
+
+    @Test
+    @DisplayName("[Fail] profile does not exist")
+    void failIfProfileDoesNotExist() {
+        // Given
+        doReturn(Optional.empty())
+                .when(profileRepository)
+                .findByNickname(FactoryPreset.NICKNAME);
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+        // When, Then
+        final TilException result = assertThrows(TilException.class, () -> tilService.readTilListByTag(FactoryPreset.NICKNAME, FactoryPreset.TAG, pageable));
+
+        assertThat(result.getStatus()).isEqualTo(TilStatus.NOT_EXISTING_PROFILE);
+    }
+
+    @Test
+    @DisplayName("[Fail] tag does not exist")
+    void failIfTagDoesNotExist() {
+        // Given
+        final Profile profile = ProfileFactory.createDefaultProfile();
+
+        final String nickname = profile.getNickname();
+
+        doReturn(Optional.of(profile))
+                .when(profileRepository)
+                .findByNickname(nickname);
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        final Page<TilTag> tilTagPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
+
+        doReturn(tilTagPage)
+                .when(tilTagRepository)
+                .findByTilProfileNicknameAndTagNameJoinFetchTil(nickname, FactoryPreset.TAG, pageable);
+
+        // When, Then
+        final TilException result = assertThrows(TilException.class, () -> tilService.readTilListByTag(nickname, FactoryPreset.TAG, pageable));
+
+        assertThat(result.getStatus()).isEqualTo(TilStatus.NOT_EXISTING_TAG);
+    }
+
+    @Test
+    @DisplayName("[Success] tils do exist")
+    void successIfTilsDoExist() {
+        // Given
+        final Profile profile = ProfileFactory.createDefaultProfile();
+
+        final String nickname = profile.getNickname();
+
+        doReturn(Optional.of(profile))
+                .when(profileRepository)
+                .findByNickname(nickname);
+
+        final Til til = TilFactory.createDefaultTil(profile);
+        final Tag tag = TagFactory.createDefaultTag();
+        final List<TilTag> tilTags = List.of(TilTagFactory.create(til, tag));
+
+        final String tagName = tag.getName();
+
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        final Page<TilTag> tilTagPage = new PageImpl<>(tilTags, pageable, tilTags.size());
+
+        doReturn(tilTagPage)
+                .when(tilTagRepository)
+                .findByTilProfileNicknameAndTagNameJoinFetchTil(nickname, tagName, pageable);
+
+        // When
+        final TilListReadResponseDto result = tilService.readTilListByTag(nickname, tagName, pageable);
+
+        // Then
+        assertThat(result.getTils().get(0).getUuid()).hasSize(36);
+        assertThat(result.getTils().get(0).getTitle()).isEqualTo(til.getTitle());
+        assertThat(result.getTils().get(0).getContent()).isEqualTo(til.getContent());
+        assertThat(result.getTotalPages()).isEqualTo(tilTagPage.getTotalPages());
+    }
+}


### PR DESCRIPTION
## Description

Add tag filtering

## Changes

- Add tag filtering to profile webpage
- Add tag filtering to TIL list read API
- Create TIL list read by tag business logic
- Create TilTag fetch join TIL pageable data access by TIL profile nickname and tag name